### PR TITLE
Remove prompt at the beginning so that the copy button does not copy it

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Running on Windows with PowerShell running inside.
 Just use the go get command (you'll need a Go and C compiler installed first):
 
 ```
-$ go get github.com/fyne-io/terminal/cmd/fyneterm
+go get github.com/fyne-io/terminal/cmd/fyneterm
 ```
 
 # Installing as an app


### PR DESCRIPTION
The copy button copies the `go get` command with the command prompt. We should remove the command prompt so that what is copied is a valid command.