### PR TITLE
Rework output processing

### DIFF
--- a/term.go
+++ b/term.go
@@ -74,6 +74,7 @@ type Terminal struct {
 	}
 	newLineMode        bool // new line mode or line feed mode
 	bracketedPasteMode bool
+	state              *parseState
 }
 
 // Cursor is used for displaying a specific cursor.


### PR DESCRIPTION
Currently the output processing is done via first casting the byte slice to a string and then processing each rune in that. This causes issues where we need to process the byte stream in a raw format.
This commit alters the processing of the output stream, only casting to a rune when appropriate.
This is a nessesarry prerequisite for transparent printing features. This commit also adds the state to the terminal struct, this allows for no side effects when dealing with multiple threads altering the state.