### PR TITLE
Fix possible crash when URI parse fails

### DIFF
--- a/osc.go
+++ b/osc.go
@@ -31,7 +31,7 @@ func (t *Terminal) handleOSC(code string) {
 
 func (t *Terminal) setDirectory(uri string) {
 	u, err := storage.ParseURI(uri)
-	if err == nil {
+	if err != nil {
 		// working around a Fyne bug where file URI does not parse host
 		off := 4
 		count := 0


### PR DESCRIPTION
Finally tracked down what could have caused the macOS reports

Fixes #40