### PR TITLE
Add session example to readme for dynamic terminal resizing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,23 @@ For example to open a terminal to an SSH connection that you have created:
 		_ = t.RunWithConnection(in, out)
 		a.Quit()
 	}()
+
+	// OPTIONAL: Dynamically resize the terminal session
+	cell := canvas.NewText("M", color.White)
+	cell.TextStyle.Monospace = true
+	cellSize = cell.MinSize()
+
+	ch := make(chan terminal.Config)
+	go func() {
+		for {
+			<-ch
+			rows := int(t.Size().Height / cellSize.Height)
+			cols := int(t.Size().Width / cellSize.Width)
+			session.WindowChange(rows, cols)
+		}
+	}()
+	t.AddListener(ch)
+
+	// Run the app
 	w.ShowAndRun()
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For example to open a terminal to an SSH connection that you have created:
 	// OPTIONAL: Dynamically resize the terminal session
 	cell := canvas.NewText("M", color.White)
 	cell.TextStyle.Monospace = true
-	cellSize = cell.MinSize()
+	cellSize := cell.MinSize()
 
 	ch := make(chan terminal.Config)
 	go func() {

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ For example to open a terminal to an SSH connection that you have created:
 	// OPTIONAL: dynamically resize the terminal session
 	cell := canvas.NewText("M", color.White)
 	cell.TextStyle.Monospace = true
-	cellHeight := int(cell.Minsize().Height)
-	cellWidth := int(cell.MinSize().Width)
+	cellHeight := int(math.Round(float64(cell.MinSize().Height)))
+	cellWidth := int(math.Round(float64(cell.MinSize().Width)))
 	ch := make(chan terminal.Config)
 	go func() {
 		mrows, mcols := 0, 0

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ use the `RunLocalShell` method after creating a `Terminal`, as follows:
 ```go
 	// win is a fyne.Window created to hold the content
 	t := terminal.New()
-	w.SetContent(t)
 
 	go func() {
 		_ = t.RunLocalShell()
 		a.Quit()
 	}()
+	
+	w.SetContent(t)
 	w.ShowAndRun()
 ```
 
@@ -85,7 +86,6 @@ For example to open a terminal to an SSH connection that you have created:
 	go session.Run("$SHELL || bash")
 
 	t := terminal.New()
-	w.SetContent(t)
 
 	go func() {
 		_ = t.RunWithConnection(in, out)
@@ -108,6 +108,6 @@ For example to open a terminal to an SSH connection that you have created:
 	}()
 	t.AddListener(ch)
 
-	// Run the app
+	w.SetContent(t)
 	w.ShowAndRun()
 ```


### PR DESCRIPTION
This is a nice thing to know for users who want the SSH terminal to resize with the app window.
The listener does a resize at app startup also which is nice.