### PR TITLE
Fix color mode handling 7 and 27

### DIFF
--- a/color.go
+++ b/color.go
@@ -85,7 +85,7 @@ func (t *Terminal) handleColorMode(modeStr string) {
 	case 4, 24: //italic
 	case 7: // reverse
 		bg, fg := t.currentBG, t.currentFG
-		if t.currentFG == nil {
+		if fg == nil {
 			t.currentBG = theme.ForegroundColor()
 		} else {
 			t.currentBG = fg
@@ -97,7 +97,7 @@ func (t *Terminal) handleColorMode(modeStr string) {
 		}
 	case 27: // reverse off
 		bg, fg := t.currentBG, t.currentFG
-		if t.currentFG != nil {
+		if fg != nil {
 			t.currentBG = nil
 		} else {
 			t.currentBG = fg

--- a/color.go
+++ b/color.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"fmt"
 	"image/color"
 	"log"
 	"strconv"
@@ -48,7 +49,7 @@ func (t *Terminal) handleColorEscape(message string) {
 		t.bold = false
 		return
 	}
-
+	fmt.Println("START")
 	modes := strings.Split(message, ";")
 	for i := 0; i < len(modes); i++ {
 		mode := modes[i]
@@ -77,7 +78,6 @@ func (t *Terminal) handleColorMode(modeStr string) {
 		fyne.LogError("Failed to parse color mode: "+modeStr, err)
 		return
 	}
-	var originalBG, originalFG color.Color
 	switch mode {
 	case 0:
 		t.currentBG, t.currentFG = nil, nil
@@ -86,19 +86,29 @@ func (t *Terminal) handleColorMode(modeStr string) {
 		t.bold = true
 	case 4, 24: //italic
 	case 7: // reverse
-		originalBG, originalFG = t.currentBG, t.currentFG
-		if originalFG == nil {
+		bg, fg := t.currentBG, t.currentFG
+		if t.currentFG == nil {
 			t.currentBG = theme.ForegroundColor()
 		} else {
-			t.currentBG = originalFG
+			t.currentBG = fg
 		}
-		if originalBG == nil {
+		if bg == nil {
 			t.currentFG = theme.DisabledButtonColor()
 		} else {
-			t.currentFG = originalBG
+			t.currentFG = bg
 		}
 	case 27: // reverse off
-		t.currentBG, t.currentFG = originalBG, originalFG
+		bg, fg := t.currentBG, t.currentFG
+		if t.currentFG != nil {
+			t.currentBG = nil
+		} else {
+			t.currentBG = fg
+		}
+		if bg != nil {
+			t.currentFG = nil
+		} else {
+			t.currentFG = bg
+		}
 	case 30, 31, 32, 33, 34, 35, 36, 37:
 		t.currentFG = basicColors[mode-30]
 	case 39:

--- a/color.go
+++ b/color.go
@@ -77,6 +77,7 @@ func (t *Terminal) handleColorMode(modeStr string) {
 		fyne.LogError("Failed to parse color mode: "+modeStr, err)
 		return
 	}
+	var originalBG, originalFG color.Color
 	switch mode {
 	case 0:
 		t.currentBG, t.currentFG = nil, nil
@@ -85,29 +86,19 @@ func (t *Terminal) handleColorMode(modeStr string) {
 		t.bold = true
 	case 4, 24: //italic
 	case 7: // reverse
-		bg := t.currentBG
-		if t.currentFG == nil {
+		originalBG, originalFG = t.currentBG, t.currentFG
+		if originalFG == nil {
 			t.currentBG = theme.ForegroundColor()
 		} else {
-			t.currentBG = t.currentFG
+			t.currentBG = originalFG
 		}
-		if bg == nil {
+		if originalBG == nil {
 			t.currentFG = theme.DisabledButtonColor()
 		} else {
-			t.currentFG = bg
+			t.currentFG = originalBG
 		}
 	case 27: // reverse off
-		bg := t.currentBG
-		if t.currentFG == theme.ForegroundColor() {
-			t.currentBG = nil
-		} else {
-			t.currentBG = t.currentFG
-		}
-		if bg == theme.DisabledButtonColor() {
-			t.currentFG = nil
-		} else {
-			t.currentFG = bg
-		}
+		t.currentBG, t.currentFG = originalBG, originalFG
 	case 30, 31, 32, 33, 34, 35, 36, 37:
 		t.currentFG = basicColors[mode-30]
 	case 39:

--- a/color.go
+++ b/color.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"fmt"
 	"image/color"
 	"log"
 	"strconv"
@@ -49,7 +48,6 @@ func (t *Terminal) handleColorEscape(message string) {
 		t.bold = false
 		return
 	}
-	fmt.Println("START")
 	modes := strings.Split(message, ";")
 	for i := 0; i < len(modes); i++ {
 		mode := modes[i]


### PR DESCRIPTION
Fix small bug where terminal was highlighting the wrong text.

before:
![before](https://github.com/fyne-io/terminal/assets/112363116/ab7f2820-3ea0-4452-95bf-383cbd43152b)

after:
![after](https://github.com/fyne-io/terminal/assets/112363116/d0891237-255d-4cd8-9a6a-3a6006511c15)

