### PR TITLE
resize when cols rows change and fix text scrambling

### DIFF
--- a/term.go
+++ b/term.go
@@ -164,7 +164,7 @@ func (t *Terminal) Resize(s fyne.Size) {
 	}
 
 	t.BaseWidget.Resize(s)
-	t.content.Resize(fyne.NewSize(float32(cols-1)*cellSize.Width, float32(rows)*cellSize.Height))
+	t.content.Resize(fyne.NewSize(float32(cols)*cellSize.Width, float32(rows)*cellSize.Height))
 
 	oldRows := int(t.config.Rows)
 	t.config.Columns, t.config.Rows = cols, rows

--- a/term.go
+++ b/term.go
@@ -156,20 +156,22 @@ func (t *Terminal) RemoveListener(listener chan Config) {
 // Resize is called when this terminal widget has been resized.
 // It ensures that the virtual terminal is within the bounds of the widget.
 func (t *Terminal) Resize(s fyne.Size) {
-	if s.Width == t.Size().Width && s.Height == t.Size().Height {
-		return
-	}
 	if s.Width < 20 { // not sure why we get tiny sizes
 		return
 	}
-	t.BaseWidget.Resize(s)
-	t.content.Resize(s)
-
 	cellSize := t.guessCellSize()
-	oldRows := int(t.config.Rows)
+	cols := uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
+	rows := uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))
+	if (t.config.Columns == cols) && (t.config.Rows == rows) {
+		return
+	}
 
-	t.config.Columns = uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
-	t.config.Rows = uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))
+	t.BaseWidget.Resize(s)
+	t.content.Resize(fyne.NewSize(float32(cols-1)*cellSize.Width, float32(rows)*cellSize.Height))
+
+	oldRows := int(t.config.Rows)
+	t.config.Columns = cols
+	t.config.Rows = rows
 	if t.scrollBottom == 0 || t.scrollBottom == oldRows-1 {
 		t.scrollBottom = int(t.config.Rows) - 1
 	}

--- a/term.go
+++ b/term.go
@@ -170,8 +170,7 @@ func (t *Terminal) Resize(s fyne.Size) {
 	t.content.Resize(fyne.NewSize(float32(cols-1)*cellSize.Width, float32(rows)*cellSize.Height))
 
 	oldRows := int(t.config.Rows)
-	t.config.Columns = cols
-	t.config.Rows = rows
+	t.config.Columns, t.config.Rows = cols, rows
 	if t.scrollBottom == 0 || t.scrollBottom == oldRows-1 {
 		t.scrollBottom = int(t.config.Rows) - 1
 	}

--- a/term.go
+++ b/term.go
@@ -156,9 +156,6 @@ func (t *Terminal) RemoveListener(listener chan Config) {
 // Resize is called when this terminal widget has been resized.
 // It ensures that the virtual terminal is within the bounds of the widget.
 func (t *Terminal) Resize(s fyne.Size) {
-	if s.Width < 20 { // not sure why we get tiny sizes
-		return
-	}
 	cellSize := t.guessCellSize()
 	cols := uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
 	rows := uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))


### PR DESCRIPTION
Reduce resize updates when making small adjustments to window.

Text would occasionally scramble when shrinking the horizontal size.
The fix is to make the t.content.Resize(...) width smaller than then t.BaseWidget.Resize(...)

Example of text staying scrambled on resize.
![scramble](https://github.com/fyne-io/terminal/assets/112363116/71be2b26-65b4-41ff-8184-bda78d3d4b8d)