### PR TITLE
Fix Terminal Character Bugs.

### DIFF
--- a/output.go
+++ b/output.go
@@ -87,7 +87,7 @@ type parseState struct {
 	vt100 rune
 }
 
-func (t *Terminal) handleOutput(buf []byte) {
+func (t *Terminal) handleOutput(buf []byte) []byte {
 	if t.hasSelectedText() {
 		t.clearSelectedText()
 	}
@@ -107,6 +107,9 @@ func (t *Terminal) handleOutput(buf []byte) {
 		r, size = utf8.DecodeRune(buf)
 		if size == 0 {
 			break
+		}
+		if r == utf8.RuneError && size == 1 {
+			return buf
 		}
 
 		if r == asciiEscape {
@@ -152,6 +155,7 @@ func (t *Terminal) handleOutput(buf []byte) {
 	if t.state.esc != noEscape {
 		t.state.esc = -1
 	}
+	return buf
 }
 
 func (t *Terminal) parseEscState(r rune) (shouldContinue bool) {

--- a/output.go
+++ b/output.go
@@ -100,8 +100,15 @@ func (t *Terminal) handleOutput(buf []byte) []byte {
 		size int
 		r    rune
 		i    = -1
+		cols = t.config.Columns
+		rows = t.config.Rows
 	)
 	for {
+		// check if terminal size has changed
+		if t.config.Columns != cols || t.config.Rows != rows {
+			break
+		}
+
 		i++
 		buf = buf[size:]
 		r, size = utf8.DecodeRune(buf)

--- a/output.go
+++ b/output.go
@@ -100,15 +100,8 @@ func (t *Terminal) handleOutput(buf []byte) []byte {
 		size int
 		r    rune
 		i    = -1
-		cols = t.config.Columns
-		rows = t.config.Rows
 	)
 	for {
-		// check if terminal size has changed
-		if t.config.Columns != cols || t.config.Rows != rows {
-			break
-		}
-
 		i++
 		buf = buf[size:]
 		r, size = utf8.DecodeRune(buf)

--- a/output.go
+++ b/output.go
@@ -108,7 +108,8 @@ func (t *Terminal) handleOutput(buf []byte) []byte {
 		if size == 0 {
 			break
 		}
-		if r == utf8.RuneError && size == 1 {
+		// UTF-8 can be 1-4 bytes long
+		if r == utf8.RuneError && size < 4 {
 			return buf
 		}
 

--- a/output.go
+++ b/output.go
@@ -108,8 +108,7 @@ func (t *Terminal) handleOutput(buf []byte) []byte {
 		if size == 0 {
 			break
 		}
-		// UTF-8 can be 1-4 bytes long
-		if r == utf8.RuneError && size < 4 {
+		if r == utf8.RuneError && size == 1 {
 			return buf
 		}
 

--- a/term.go
+++ b/term.go
@@ -287,10 +287,7 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		if len(leftOver) > 0 {
-			buf = append(leftOver, buf[:num]...)
-		}
-		leftOver = t.handleOutput(buf[:num])
+		leftOver = t.handleOutput(append(leftOver, buf[:num]...))
 		if num < bufLen {
 			t.Refresh()
 		}

--- a/term.go
+++ b/term.go
@@ -290,6 +290,7 @@ func (t *Terminal) run() {
 		if len(leftOver) > 0 {
 			buf = append(leftOver, buf[:num]...)
 			num += len(leftOver)
+			bufLen += len(leftOver)
 		}
 		leftOver = t.handleOutput(buf[:num])
 		if num < bufLen {

--- a/term.go
+++ b/term.go
@@ -287,7 +287,11 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		leftOver = t.handleOutput(append(leftOver, buf[:num]...))
+		if len(leftOver) > 0 {
+			buf = append(leftOver, buf...)
+			num++
+		}
+		leftOver = t.handleOutput(buf[:num])
 		if num < bufLen {
 			t.Refresh()
 		}

--- a/term.go
+++ b/term.go
@@ -288,7 +288,7 @@ func (t *Terminal) run() {
 		}
 
 		if len(leftOver) > 0 {
-			buf = append(leftOver, buf...)
+			buf = append(leftOver, buf[:num]...)
 			num++
 		}
 		leftOver = t.handleOutput(buf[:num])

--- a/term.go
+++ b/term.go
@@ -271,8 +271,9 @@ func (t *Terminal) guessCellSize() fyne.Size {
 }
 
 func (t *Terminal) run() {
-	bufLen := 4069
+	bufLen := 4096
 	buf := make([]byte, bufLen)
+	leftOver := make([]byte, 1)
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {
@@ -286,7 +287,7 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		t.handleOutput(buf[:num])
+		leftOver = t.handleOutput(append(leftOver, buf[:num]...))
 		if num < bufLen {
 			t.Refresh()
 		}

--- a/term.go
+++ b/term.go
@@ -273,7 +273,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 func (t *Terminal) run() {
 	bufLen := 4096
 	buf := make([]byte, bufLen)
-	leftOver := make([]byte, 1)
+	leftOver := make([]byte, 3) // UTF-8 leftovers
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {

--- a/term.go
+++ b/term.go
@@ -290,10 +290,9 @@ func (t *Terminal) run() {
 		if len(leftOver) > 0 {
 			buf = append(leftOver, buf[:num]...)
 			num += len(leftOver)
-			bufLen += len(leftOver)
 		}
 		leftOver = t.handleOutput(buf[:num])
-		if num < bufLen {
+		if num < bufLen+len(leftOver) {
 			t.Refresh()
 		}
 	}

--- a/term.go
+++ b/term.go
@@ -289,7 +289,7 @@ func (t *Terminal) run() {
 
 		if len(leftOver) > 0 {
 			buf = append(leftOver, buf[:num]...)
-			num++
+			num += len(leftOver)
 		}
 		leftOver = t.handleOutput(buf[:num])
 		if num < bufLen {

--- a/term.go
+++ b/term.go
@@ -287,12 +287,13 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		if len(leftOver) > 0 {
+		lenLeftOver := len(leftOver)
+		if lenLeftOver > 0 {
 			buf = append(leftOver, buf[:num]...)
-			num += len(leftOver)
+			num += lenLeftOver
 		}
 		leftOver = t.handleOutput(buf[:num])
-		if num < bufLen+len(leftOver) {
+		if num < bufLen+lenLeftOver {
 			t.Refresh()
 		}
 	}

--- a/term.go
+++ b/term.go
@@ -273,7 +273,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 func (t *Terminal) run() {
 	bufLen := 4096
 	buf := make([]byte, bufLen)
-	leftOver := make([]byte, 3) // UTF-8 leftovers
+	var leftOver []byte
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {
@@ -287,7 +287,10 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		leftOver = t.handleOutput(append(leftOver, buf[:num]...))
+		if len(leftOver) > 0 {
+			buf = append(leftOver, buf[:num]...)
+		}
+		leftOver = t.handleOutput(buf[:num])
 		if num < bufLen {
 			t.Refresh()
 		}


### PR DESCRIPTION
Fix for #9 
The buffer cuts some chars in half since UTF-8 isn't always 1 byte.
Returning the byte and prepending it to the next buffer fixes the issue.
Also changed bufLen from 4069 to 4096.

~~Added:
If columns or rows changes during handleOutput then break loop.
It looked like output was being fully rendered for every size change which was sluggish.~~
