### PR TITLE
Fix/control keys

### DIFF
--- a/input.go
+++ b/input.go
@@ -170,13 +170,13 @@ func (t *Terminal) TypedShortcut(s fyne.Shortcut) {
 			off := ds.KeyName[0] - 'A' + 1
 			switch {
 			case ds.Key() == fyne.KeySpace:
+				fallthrough
+			case ds.Key() == "@":
 				off = 0
-			case off < 0:
-				off = 0
-			case off > 31:
-				off = 31
+				fallthrough
+			case off >= 1 && off <= 31:
+				_, _ = t.in.Write([]byte{off})
 			}
-			_, _ = t.in.Write([]byte{off})
 		}
 		return
 	}

--- a/input.go
+++ b/input.go
@@ -167,14 +167,15 @@ func (t *Terminal) TypedShortcut(s fyne.Shortcut) {
 
 		// handle CTRL+A to CTRL+_ and everything inbetween
 		if ds.Modifier == fyne.KeyModifierControl {
-			off := ds.KeyName[0] - 'A' + 1
+			char := ds.KeyName[0]
+			off := char - 'A' + 1
 			switch {
 			case ds.Key() == fyne.KeySpace:
 				fallthrough
 			case ds.Key() == "@":
 				off = 0
 				fallthrough
-			case off >= 1 && off <= 31:
+			case char >= 'A' && char <= '_':
 				_, _ = t.in.Write([]byte{off})
 			}
 		}

--- a/input.go
+++ b/input.go
@@ -165,8 +165,19 @@ func (t *Terminal) TypedShortcut(s fyne.Shortcut) {
 	if ds, ok := s.(*desktop.CustomShortcut); ok {
 		t.ShortcutHandler.TypedShortcut(s) // it's not clear how we can check if this consumed the event
 
-		off := ds.KeyName[0] - 'A' + 1
-		_, _ = t.in.Write([]byte{off})
+		// handle CTRL+A to CTRL+_ and everything inbetween
+		if ds.Modifier == fyne.KeyModifierControl {
+			off := ds.KeyName[0] - 'A' + 1
+			switch {
+			case ds.Key() == fyne.KeySpace:
+				off = 0
+			case off < 0:
+				off = 0
+			case off > 31:
+				off = 31
+			}
+			_, _ = t.in.Write([]byte{off})
+		}
 		return
 	}
 

--- a/input_test.go
+++ b/input_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/driver/desktop"
 )
 
 // NopCloser returns a WriteCloser with a no-op Close method wrapping
@@ -123,6 +124,65 @@ func TestTerminal_TypedKey_LineMode(t *testing.T) {
 			got := inBuffer.Bytes()
 			if !bytes.Equal(got, tt.want) {
 				t.Errorf("TypedKey() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTerminal_TypedShortcut(t *testing.T) {
+	tests := map[string]struct {
+		shortcut fyne.Shortcut
+		want     []byte
+	}{
+		"LeftOption+U": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierAlt,
+				KeyName:  fyne.KeyU},
+			want: []byte{},
+		},
+		"Control+@": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierControl,
+				KeyName:  "@"},
+			want: []byte{0},
+		},
+		"Control+Space": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierControl,
+				KeyName:  fyne.KeySpace},
+			want: []byte{0},
+		},
+		"Control+C": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierControl,
+				KeyName:  fyne.KeyC},
+			want: []byte{3},
+		},
+		"Control+_": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierControl,
+				KeyName:  "_"},
+			want: []byte{31},
+		},
+		"Control+X": {
+			shortcut: &desktop.CustomShortcut{
+				Modifier: fyne.KeyModifierControl,
+				KeyName:  fyne.KeyX},
+			want: []byte{24},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Creating a mock terminal
+			inBuffer := bytes.NewBuffer([]byte{})
+			term := &Terminal{in: NopCloser(inBuffer)}
+
+			term.TypedShortcut(tt.shortcut)
+
+			got := inBuffer.Bytes()
+			if !bytes.Equal(got, tt.want) {
+				t.Errorf("TypedShortcut() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Control key handling was broken. FyneTerm sent invalid keys such as the NAK character for ALT+U for example.

Please review both commits individually so we can choose an implementation