### PR TITLE
Expose an easy way to run a function upon terminal window change

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,15 @@ To load a terminal widget and launch the current shell (works on macOS and Linux
 use the `RunLocalShell` method after creating a `Terminal`, as follows:
 
 ```go
-	// win is a fyne.Window created to hold the content
+	// run new terminal and close app on terminal exit.
 	t := terminal.New()
-	w.SetContent(t)
-
 	go func() {
 		_ = t.RunLocalShell()
 		a.Quit()
 	}()
+	
+	// w is a fyne.Window created to hold the content
+	w.SetContent(t)
 	w.ShowAndRun()
 ```
 
@@ -78,18 +79,20 @@ For example to open a terminal to an SSH connection that you have created:
 
 ```go
 	// session is an *ssh.Session from golang.org/x/crypto/ssh
-	// win is a fyne.Window created to hold the content
 	in, _ := session.StdinPipe()
 	out, _ := session.StdoutPipe()
-
 	go session.Run("$SHELL || bash")
-
+	
+	// run new terminal and close app on terminal exit.
 	t := terminal.New()
-	w.SetContent(t)
-
 	go func() {
-		_ = t.RunWithConnection(in, out)
+		_ = t.RunWithConnection(in, out, func(rows int, cols int) {
+			session.WindowChange(rows, cols)
+		})
 		a.Quit()
 	}()
+
+	// w is a fyne.Window created to hold the content
+	w.SetContent(t)
 	w.ShowAndRun()
 ```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For example to open a terminal to an SSH connection that you have created:
 	t := terminal.New()
 	go func() {
 		_ = t.RunWithConnection(in, out, func(rows int, cols int) {
+			// Update session window with fyne window resize
 			session.WindowChange(rows, cols)
 		})
 		a.Quit()

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To load a terminal widget and launch the current shell (works on macOS and Linux
 use the `RunLocalShell` method after creating a `Terminal`, as follows:
 
 ```go
-	// run new terminal and close app on terminal exit.
+	// run new terminal and close app on terminal exit
 	t := terminal.New()
 	go func() {
 		_ = t.RunLocalShell()
@@ -83,7 +83,7 @@ For example to open a terminal to an SSH connection that you have created:
 	out, _ := session.StdoutPipe()
 	go session.Run("$SHELL || bash")
 	
-	// run new terminal and close app on terminal exit.
+	// run new terminal and close app on terminal exit
 	t := terminal.New()
 	go func() {
 		_ = t.RunWithConnection(in, out, func(rows int, cols int) {

--- a/term.go
+++ b/term.go
@@ -322,9 +322,9 @@ func (t *Terminal) RunWithConnection(in io.WriteCloser, out io.Reader, windowCha
 	// monitor window size changes and run windowChangeFunc
 	ch := make(chan Config)
 	go func() {
-		<-ch
 		mr, mc := uint(0), uint(0)
 		for {
+			<-ch
 			r, c := t.config.Rows, t.config.Columns
 			if mr == r && mc == c {
 				continue

--- a/term.go
+++ b/term.go
@@ -322,6 +322,7 @@ func (t *Terminal) RunWithConnection(in io.WriteCloser, out io.Reader, windowCha
 	// monitor window size changes and run windowChangeFunc
 	ch := make(chan Config)
 	go func() {
+		<-ch
 		mr, mc := uint(0), uint(0)
 		for {
 			r, c := t.config.Rows, t.config.Columns


### PR DESCRIPTION
This currently modifies RunWithConnection which is a breaking change.
Should this be split out into another function like OnWindowChange?

Returning the rows and cols through the function is nice since those weren't exposed before.