### PR TITLE
Fix buffer corruption that is still happening on run()

### DIFF
--- a/term.go
+++ b/term.go
@@ -285,13 +285,12 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		lenLeftOver := len(leftOver)
-		if lenLeftOver > 0 {
-			buf = append(leftOver, buf[:num]...)
-			num += lenLeftOver
-		}
-		leftOver = t.handleOutput(buf[:num])
-		if num < bufLen+lenLeftOver {
+		fullBuf := make([]byte, len(leftOver)+num)
+		copy(fullBuf, leftOver)
+		copy(fullBuf[len(leftOver):], buf[:num])
+		leftOver = t.handleOutput(fullBuf)
+
+		if len(fullBuf) < bufLen {
 			t.Refresh()
 		}
 	}

--- a/term.go
+++ b/term.go
@@ -269,7 +269,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 }
 
 func (t *Terminal) run() {
-	bufLen := 4096
+	bufLen := 32768 // 32k buffer for output
 	buf := make([]byte, bufLen)
 	var leftOver []byte
 	for {

--- a/term.go
+++ b/term.go
@@ -271,7 +271,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 func (t *Terminal) run() {
 	bufLen := 4096
 	buf := make([]byte, bufLen)
-	leftOver := make([]byte, bufLen+3) // +3 for utf8 partials
+	var leftOver []byte
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {
@@ -285,10 +285,8 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		leftOver = append(leftOver, buf[:num]...)
-		leftOver = t.handleOutput(leftOver)
-
-		if len(leftOver) < bufLen {
+		leftOver = t.handleOutput(append(leftOver, buf[:num]...))
+		if len(leftOver) == 0 {
 			t.Refresh()
 		}
 	}

--- a/term.go
+++ b/term.go
@@ -271,7 +271,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 func (t *Terminal) run() {
 	bufLen := 4096
 	buf := make([]byte, bufLen)
-	var leftOver []byte
+	leftOver := make([]byte, bufLen+3) // +3 for utf8 partials
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {

--- a/term.go
+++ b/term.go
@@ -285,12 +285,10 @@ func (t *Terminal) run() {
 			fyne.LogError("pty read error", err)
 		}
 
-		fullBuf := make([]byte, len(leftOver)+num)
-		copy(fullBuf, leftOver)
-		copy(fullBuf[len(leftOver):], buf[:num])
-		leftOver = t.handleOutput(fullBuf)
+		leftOver = append(leftOver, buf[:num]...)
+		leftOver = t.handleOutput(leftOver)
 
-		if len(fullBuf) < bufLen {
+		if len(leftOver) < bufLen {
 			t.Refresh()
 		}
 	}

--- a/term.go
+++ b/term.go
@@ -269,8 +269,7 @@ func (t *Terminal) guessCellSize() fyne.Size {
 }
 
 func (t *Terminal) run() {
-	bufLen := 32768 // 32k buffer for output
-	buf := make([]byte, bufLen)
+	buf := make([]byte, 32768) // 32KB buffer for output
 	var leftOver []byte
 	for {
 		num, err := t.out.Read(buf)


### PR DESCRIPTION
Buffer corruption was still happening ~~due to the use of Append instead of Copy.  Copy is more precise.~~

I've tried to make an if statement to skip the Copying on when leftover is length zero, but for some reason it always adds back in corruption.  I'm really not sure why other than deeper memory handling that I'm not seeing.