### PR TITLE
Add escapeInsertCharacters function to handle '@' character

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -130,6 +131,9 @@ func escapeColorMode(t *Terminal, msg string) {
 
 func escapeDeleteChars(t *Terminal, msg string) {
 	i, _ := strconv.Atoi(msg)
+	if i == 0 {
+		i = 1
+	}
 	right := t.cursorCol + i
 
 	row := t.content.Row(t.cursorRow)
@@ -139,6 +143,7 @@ func escapeDeleteChars(t *Terminal, msg string) {
 	}
 
 	t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: cells})
+	fmt.Println(t.content.Text())
 }
 
 func escapeEraseInLine(t *Terminal, msg string) {

--- a/escape.go
+++ b/escape.go
@@ -9,7 +9,7 @@ import (
 )
 
 var escapes = map[rune]func(*Terminal, string){
-	'@': escapeInsertCharacters,
+	'@': escapeInsertChars,
 	'A': escapeMoveCursorUp,
 	'B': escapeMoveCursorDown,
 	'C': escapeMoveCursorRight,
@@ -180,7 +180,7 @@ func escapeEraseInScreen(t *Terminal, msg string) {
 	}
 }
 
-func escapeInsertCharacters(t *Terminal, msg string) {
+func escapeInsertChars(t *Terminal, msg string) {
 	chars, _ := strconv.Atoi(msg)
 	if chars == 0 {
 		chars = 1

--- a/escape.go
+++ b/escape.go
@@ -1,7 +1,6 @@
 package terminal
 
 import (
-	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -143,7 +142,6 @@ func escapeDeleteChars(t *Terminal, msg string) {
 	}
 
 	t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: cells})
-	fmt.Println(t.content.Text())
 }
 
 func escapeEraseInLine(t *Terminal, msg string) {

--- a/escape.go
+++ b/escape.go
@@ -134,7 +134,6 @@ func escapeDeleteChars(t *Terminal, msg string) {
 
 	row := t.content.Row(t.cursorRow)
 	cells := row.Cells[:t.cursorCol]
-	cells = append(cells, make([]widget.TextGridCell, i)...)
 	if right < len(row.Cells) {
 		cells = append(cells, row.Cells[right:]...)
 	}

--- a/escape.go
+++ b/escape.go
@@ -9,6 +9,7 @@ import (
 )
 
 var escapes = map[rune]func(*Terminal, string){
+	'@': escapeInsertCharacters,
 	'A': escapeMoveCursorUp,
 	'B': escapeMoveCursorDown,
 	'C': escapeMoveCursorRight,
@@ -177,6 +178,25 @@ func escapeEraseInScreen(t *Terminal, msg string) {
 	case 2:
 		t.clearScreen()
 	}
+}
+
+func escapeInsertCharacters(t *Terminal, msg string) {
+	chars, _ := strconv.Atoi(msg)
+	if chars == 0 {
+		chars = 1
+	}
+
+	newCells := make([]widget.TextGridCell, chars)
+	cellStyle := &widget.CustomTextGridStyle{FGColor: t.currentFG, BGColor: t.currentBG}
+	for i := range newCells {
+		newCells[i] = widget.TextGridCell{
+			Rune:  ' ',
+			Style: cellStyle,
+		}
+	}
+
+	row := &t.content.Rows[t.cursorRow]
+	row.Cells = append(row.Cells[:t.cursorCol], append(newCells, row.Cells[t.cursorCol:]...)...)
 }
 
 func escapeInsertLines(t *Terminal, msg string) {

--- a/escape_test.go
+++ b/escape_test.go
@@ -18,6 +18,20 @@ func TestClearScreen(t *testing.T) {
 	assert.Equal(t, "", term.content.Text())
 }
 
+func TestInsertDeleteChars(t *testing.T) {
+	term := New()
+	term.config.Columns = 5
+	term.config.Rows = 2
+	term.handleOutput([]byte("Hello"))
+	assert.Equal(t, "Hello", term.content.Text())
+
+	term.moveCursor(0, 2)
+	term.handleEscape("2@")
+	assert.Equal(t, "He  llo", term.content.Text())
+	term.handleEscape("3P")
+	assert.Equal(t, "Helo", term.content.Text())
+}
+
 func TestEraseLine(t *testing.T) {
 	term := New()
 	term.config.Columns = 5


### PR DESCRIPTION
This allows for character inserting which works great as 1@ escapes were not being handled.

This did reveal another issue where 1P escapeDeleteChars is working, but the terminal isn't refreshing (
t.content.Refresh() and t.Refresh() does not work) upon delete leaving blank spaces.  Resizing the terminal causes characters to be displayed correctly.

Is there a way to manually update the display?