### PR TITLE
output.go return new buf and simplify term.go

### DIFF
--- a/output.go
+++ b/output.go
@@ -109,7 +109,9 @@ func (t *Terminal) handleOutput(buf []byte) []byte {
 			break
 		}
 		if r == utf8.RuneError && size == 1 {
-			return buf
+			leftOver := make([]byte, len(buf))
+			copy(leftOver, buf)
+			return leftOver
 		}
 
 		if r == asciiEscape {

--- a/term.go
+++ b/term.go
@@ -280,17 +280,14 @@ func (t *Terminal) run() {
 			} else if err, ok := err.(*os.PathError); ok && err.Err.Error() == "input/output error" {
 				break // broken pipe, terminal exit
 			}
-
 			fyne.LogError("pty read error", err)
 		}
 
-		lenLeftOver := len(leftOver)
-		fullBuf := buf
-		if lenLeftOver > 0 {
-			fullBuf = append(leftOver, buf[:num]...)
-			num += lenLeftOver
+		if len(leftOver) > 0 {
+			leftOver = t.handleOutput(append(leftOver, buf[:num]...))
+		} else {
+			leftOver = t.handleOutput(buf[:num])
 		}
-		leftOver = t.handleOutput(fullBuf[:num])
 		if len(leftOver) == 0 {
 			t.Refresh()
 		}


### PR DESCRIPTION
In reference to #69

The whole issue was that we were modifying the original buffer then returning it.  Simply copying the buffer before returning it allows us to use an if statement safely without having to copy(append) every time.  Sorry I should have realized that sooner.