### PR TITLE
RFE: Expose exit code from Terminal's shell #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ a `Terminal`, as follows:
 	t := terminal.New()
 	go func() {
 		_ = t.RunLocalShell()
-		// Optionally use ExitCode() to get the shell's exit code.
-		// It will return -1 if called before actual exit - just like
-		// https://pkg.go.dev/os#ProcessState 's ExitCode() would.
 		log.Printf("Terminal's shell exited with exit code: %d", t.ExitCode())
 		a.Quit()
 	}()

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ a `Terminal`, as follows:
 	t := terminal.New()
 	go func() {
 		_ = t.RunLocalShell()
+		// Optionally use ExitCode() to get the shell's exit code.
+		// It will return -1 if called before actual exit - just like
+		// https://pkg.go.dev/os#ProcessState 's ExitCode() would.
 		log.Printf("Terminal's shell exited with exit code: %d", t.ExitCode())
 		a.Quit()
 	}()

--- a/README.md
+++ b/README.md
@@ -45,29 +45,29 @@ Already planned is:
 * Scroll-back
 * Background and font/size customisation
 * Split panels
-* Windows support
 
 # Library
 
 You can also use this project as a library to create your own
 terminal based applications, using the import path "github.com/fyne-io/terminal".
 
-There are two modes, using the default shell (macOS and Linux) or connecting
-to a remote shell.
+There are two modes, using the default shell or connecting to a remote shell.
 
 ## Local Shell
 
-To load a terminal widget and launch the current shell (works on macOS and Linux)
-use the `RunLocalShell` method after creating a `Terminal`, as follows:
+To load a terminal widget and launch the current shell (works on macOS and Linux;
+on Windows, it always uses PowerShell) use the `RunLocalShell` method after creating
+a `Terminal`, as follows:
 
 ```go
 	// run new terminal and close app on terminal exit.
 	t := terminal.New()
 	go func() {
 		_ = t.RunLocalShell()
+		log.Printf("Terminal's shell exited with exit code: %d", t.ExitCode())
 		a.Quit()
 	}()
-	
+
 	// w is a fyne.Window created to hold the content
 	w.SetContent(t)
 	w.ShowAndRun()
@@ -82,7 +82,7 @@ For example to open a terminal to an SSH connection that you have created:
 	in, _ := session.StdinPipe()
 	out, _ := session.StdoutPipe()
 	go session.Run("$SHELL || bash")
-	
+
 	// run new terminal and close app on terminal exit.
 	t := terminal.New()
 	go func() {

--- a/term.go
+++ b/term.go
@@ -218,7 +218,9 @@ func (t *Terminal) Text() string {
 	return t.content.Text()
 }
 
-// ExitCode returns the exit code from the terminal's shell
+// ExitCode returns the exit code from the terminal's shell.
+// Returns -1 if called before shell was started or before shell exited.
+// Also returns -1 if shell was terminated by a signal.
 func (t *Terminal) ExitCode() int {
 	if t.cmd == nil {
 		return -1

--- a/term_test.go
+++ b/term_test.go
@@ -16,6 +16,11 @@ func TestNewTerminal(t *testing.T) {
 	assert.NotNil(t, term.content)
 }
 
+func TestExitCode(t *testing.T) {
+	term := New()
+	assert.Equal(t, term.ExitCode(), int(-1))
+}
+
 func TestTerminal_Resize(t *testing.T) {
 	term := New()
 	term.Resize(fyne.NewSize(45, 45))

--- a/term_unix.go
+++ b/term_unix.go
@@ -37,6 +37,7 @@ func (t *Terminal) startPTY() (io.WriteCloser, io.Reader, io.Closer, error) {
 	env = append(env, "TERM=xterm-256color")
 	c := exec.Command(shell)
 	c.Env = env
+	t.cmd = c
 
 	// Start the command with a pty.
 	f, err := pty.Start(c)

--- a/term_windows.go
+++ b/term_windows.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"syscall"
 
 	"github.com/ActiveState/termtest/conpty"
@@ -33,15 +34,17 @@ func (t *Terminal) startPTY() (io.WriteCloser, io.Reader, io.Closer, error) {
 		return nil, nil, nil, err
 	}
 
+	t.cmd = &exec.Cmd{}
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	go func() {
-		_, err := process.Wait()
+		ps, err := process.Wait()
 		if err != nil {
 			log.Fatalf("Error waiting for process: %v", err)
 		}
+		t.cmd.ProcessState = ps
 		if t.pty != nil {
 			t.pty = nil
 			_ = cpty.Close()


### PR DESCRIPTION
As discussed in issue #72 
- Don't panic if ExitCode() is called before RunLocalShell() - return -1 like os.exec would before wait()
- Add a minimal test for the above
- Add windows support
- Update documentation/README with example usage
