### PR TITLE
Fix/min size

### DIFF
--- a/cmd/fyneterm/main.go
+++ b/cmd/fyneterm/main.go
@@ -23,8 +23,10 @@ import (
 const termOverlay = fyne.ThemeColorName("termOver")
 
 var (
-	DefaultRows float32 = 24.0 // The default number of rows in the terminal.
-	DefaultCols float32 = 80.0 // The default number of columns in the terminal.
+	// DefaultRows The default number of rows in the terminal.
+	DefaultRows float32 = 24.0
+	// DefaultCols The default number of columns in the terminal.
+	DefaultCols float32 = 80.0
 )
 
 var (

--- a/cmd/fyneterm/main.go
+++ b/cmd/fyneterm/main.go
@@ -23,8 +23,8 @@ import (
 const termOverlay = fyne.ThemeColorName("termOver")
 
 var (
-	DefaultRows float32 = 24.0
-	DefaultCols float32 = 80.0
+	DefaultRows float32 = 24.0 // The default number of rows in the terminal.
+	DefaultCols float32 = 80.0 // The default number of columns in the terminal.
 )
 
 var (

--- a/cmd/fyneterm/main.go
+++ b/cmd/fyneterm/main.go
@@ -23,6 +23,11 @@ import (
 const termOverlay = fyne.ThemeColorName("termOver")
 
 var (
+	DefaultRows float32 = 24.0
+	DefaultCols float32 = 80.0
+)
+
+var (
 	localizer *i18n.Localizer
 	sizer     *termTheme
 )
@@ -104,9 +109,10 @@ func newTerminalWindow(a fyne.App, th fyne.Theme, debug bool) fyne.Window {
 	t.SetDebug(debug)
 	setupListener(t, w)
 	w.SetContent(container.NewStack(bg, img, over, t))
-
 	cellSize := guessCellSize()
-	w.Resize(fyne.NewSize(cellSize.Width*80, cellSize.Height*24))
+	minSize := fyne.NewSize(cellSize.Width*DefaultCols, cellSize.Height*DefaultRows)
+	t.SetMinSize(minSize)
+	w.Resize(minSize)
 	w.Canvas().Focus(t)
 
 	t.AddShortcut(&desktop.CustomShortcut{KeyName: fyne.KeyN, Modifier: fyne.KeyModifierControl | fyne.KeyModifierShift},

--- a/position.go
+++ b/position.go
@@ -15,7 +15,7 @@ func (r position) String() string {
 }
 
 func (t *Terminal) getTermPosition(pos fyne.Position) position {
-	cell := t.guessCellSize()
+	cell := guessCellSize()
 	col := int(pos.X/cell.Width) + 1
 	row := int(pos.Y/cell.Height) + 1
 	return position{col, row}

--- a/render.go
+++ b/render.go
@@ -41,7 +41,7 @@ func (r *render) Destroy() {
 }
 
 func (r *render) moveCursor() {
-	cell := r.term.guessCellSize()
+	cell := guessCellSize()
 	r.term.cursor.Move(fyne.NewPos(cell.Width*float32(r.term.cursorCol), cell.Height*float32(r.term.cursorRow)))
 }
 
@@ -52,7 +52,7 @@ func (t *Terminal) refreshCursor() {
 	} else {
 		t.cursor.FillColor = theme.PrimaryColor()
 	}
-	t.cursor.Resize(fyne.NewSize(cursorWidth, t.guessCellSize().Height))
+	t.cursor.Resize(fyne.NewSize(cursorWidth, guessCellSize().Height))
 	t.cursor.Refresh()
 }
 
@@ -60,7 +60,7 @@ func (t *Terminal) refreshCursor() {
 func (t *Terminal) CreateRenderer() fyne.WidgetRenderer {
 	t.cursor = canvas.NewRectangle(theme.PrimaryColor())
 	t.cursor.Hidden = true
-	t.cursor.Resize(fyne.NewSize(cursorWidth, t.guessCellSize().Height))
+	t.cursor.Resize(fyne.NewSize(cursorWidth, guessCellSize().Height))
 
 	r := &render{term: t}
 	t.cursorMoved = r.moveCursor

--- a/term.go
+++ b/term.go
@@ -119,7 +119,7 @@ func (t *Terminal) AddListener(listener chan Config) {
 
 // MinSize provides a size large enough that a terminal could technically funcion.
 func (t *Terminal) MinSize() fyne.Size {
-	s := t.guessCellSize()
+	s := guessCellSize()
 	return fyne.NewSize(s.Width*2.5, s.Height*1.2) // just enough to get a terminal init
 }
 
@@ -178,7 +178,7 @@ func (t *Terminal) RemoveListener(listener chan Config) {
 // Resize is called when this terminal widget has been resized.
 // It ensures that the virtual terminal is within the bounds of the widget.
 func (t *Terminal) Resize(s fyne.Size) {
-	cellSize := t.guessCellSize()
+	cellSize := guessCellSize()
 	cols := uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
 	rows := uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))
 	if (t.config.Columns == cols) && (t.config.Rows == rows) {
@@ -292,7 +292,7 @@ func (t *Terminal) close() error {
 }
 
 // don't call often - should we cache?
-func (t *Terminal) guessCellSize() fyne.Size {
+func guessCellSize() fyne.Size {
 	cell := canvas.NewText("M", color.White)
 	cell.TextStyle.Monospace = true
 

--- a/term.go
+++ b/term.go
@@ -84,6 +84,7 @@ type Terminal struct {
 	printData          []byte
 	printer            Printer
 	cmd                *exec.Cmd
+	minSize            fyne.Size
 }
 
 // Printer is used for spooling print data when its received.
@@ -119,8 +120,8 @@ func (t *Terminal) AddListener(listener chan Config) {
 
 // MinSize provides a size large enough that a terminal could technically funcion.
 func (t *Terminal) MinSize() fyne.Size {
-	s := guessCellSize()
-	return fyne.NewSize(s.Width*2.5, s.Height*1.2) // just enough to get a terminal init
+
+	return t.minSize
 }
 
 // MouseDown handles the down action for desktop mouse events.
@@ -436,14 +437,15 @@ func (t *Terminal) startingDir() string {
 
 // New sets up a new terminal instance with the bash shell
 func New() *Terminal {
+	s := guessCellSize()
 	t := &Terminal{
 		mouseCursor:      desktop.DefaultCursor,
 		highlightBitMask: 0x55,
+		minSize:          fyne.NewSize(s.Width*2.5, s.Height*1.2),
 	}
 	t.ExtendBaseWidget(t)
 	t.content = widget2.NewTermGrid()
 	t.setupShortcuts()
-
 	return t
 }
 
@@ -494,4 +496,9 @@ func (t *Terminal) Dragged(d *fyne.DragEvent) {
 // DragEnd is called by fyne when the left mouse is released after a Drag event.
 func (t *Terminal) DragEnd() {
 	t.selecting = false
+}
+
+// SetMinSize specifies the smallest size this object should be.
+func (t *Terminal) SetMinSize(size fyne.Size) {
+	t.minSize = size
 }


### PR DESCRIPTION
When resizing below 80*24 rows/cols the rendering breaks with duplicate lines, lost content etc. This change prevents this by fixing the size to a minimum while allowing the previous behaviour.