### PR TITLE
Resolve panic on closing SSH session in fyne-io/terminal

### DIFF
--- a/term.go
+++ b/term.go
@@ -306,8 +306,10 @@ func (t *Terminal) run() {
 	for {
 		num, err := t.out.Read(buf)
 		if err != nil {
-			// wait for cmd (shell) to exit, populates ProcessState.ExitCode
-			t.cmd.Wait()
+			if t.cmd != nil {
+				// wait for cmd (shell) to exit, populates ProcessState.ExitCode
+				t.cmd.Wait()
+			}
 			// this is the pre-go 1.13 way to check for the read failing (terminal closed)
 			if err.Error() == "EOF" {
 				break // term exit on macOS


### PR DESCRIPTION
## Resolve Panic on Closing SSH Session in fyne-io/terminal

**Problem:**
When using the `fyne-io/terminal` library to establish an SSH connection, calling `t.Exit()` or `session.Close()` triggers a runtime panic "invalid memory address or nil pointer dereference". This occurs because `t.cmd.Wait()` is called in the `Terminal.run` method without prior initialization of `t.cmd`.

**Root Cause:**
The issue stems from the `RunWithConnection` method where `t.cmd` is not set, but `run()` attempts to wait on this unassigned command object if an error occurs during stream reading, specifically after an SSH session ends.

**Solution:**
This pull request introduces a nil check for `t.cmd` within the main loop of `Terminal.run` method. By checking if `t.cmd` is non-nil before attempting to call `t.cmd.Wait()`, we prevent the nil pointer dereference that leads to the application crash.

**Detailed Changes:**
- Added a nil check for `t.cmd` in `Terminal.run` before calling `t.cmd.Wait()`.
- Ensured that the terminal handles unexpected SSH session closures smoothly without leading to a runtime panic.

**Impact:**
This change significantly improves the stability and reliability of applications using the `fyne-io/terminal` library for managing SSH sessions, especially in scenarios where sessions might be dynamically controlled or terminated.

Your review and feedback would be highly appreciated to get this critical fix incorporated into the main branch. Thank you!

