### PR TITLE
Update term_windows.go

### DIFF
--- a/term_windows.go
+++ b/term_windows.go
@@ -28,6 +28,7 @@ func (t *Terminal) startPTY() (io.WriteCloser, io.Reader, io.Closer, error) {
 		[]string{},
 		&syscall.ProcAttr{
 			Env: os.Environ(),
+			Dir: t.startingDir(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
fix: term_windows.go t.SetStartDir() is not working

https://github.com/ActiveState/termtest/blob/master/conpty/conpty_windows.go
// StartProcess assumes that argv0 is relative to attr.Dir,
// because it implies Chdir(attr.Dir) before executing argv0.
// Windows CreateProcess assumes the opposite: it looks for
// argv0 relative to the current directory, and, only once the new
// process is started, it does Chdir(attr.Dir). We are adjusting
// for that difference here by making argv0 absolute.