### PR TITLE
Refactor terminal copy and paste behavior

### DIFF
--- a/term.go
+++ b/term.go
@@ -128,10 +128,8 @@ func (t *Terminal) MouseDown(ev *desktop.MouseEvent) {
 	if t.hasSelectedText() {
 		t.copySelectedText(fyne.CurrentApp().Clipboard())
 		t.clearSelectedText()
-	} else {
-		if ev.Button == desktop.MouseButtonSecondary {
-			t.pasteText(fyne.CurrentApp().Clipboard())
-		}
+	} else if ev.Button == desktop.MouseButtonSecondary {
+		t.pasteText(fyne.CurrentApp().Clipboard())
 	}
 
 	if t.onMouseDown == nil {

--- a/term.go
+++ b/term.go
@@ -126,7 +126,12 @@ func (t *Terminal) MinSize() fyne.Size {
 // MouseDown handles the down action for desktop mouse events.
 func (t *Terminal) MouseDown(ev *desktop.MouseEvent) {
 	if t.hasSelectedText() {
+		t.copySelectedText(fyne.CurrentApp().Clipboard())
 		t.clearSelectedText()
+	} else {
+		if ev.Button == desktop.MouseButtonSecondary {
+			t.pasteText(fyne.CurrentApp().Clipboard())
+		}
 	}
 
 	if t.onMouseDown == nil {
@@ -142,9 +147,6 @@ func (t *Terminal) MouseDown(ev *desktop.MouseEvent) {
 
 // MouseUp handles the up action for desktop mouse events.
 func (t *Terminal) MouseUp(ev *desktop.MouseEvent) {
-	if ev.Button == desktop.MouseButtonSecondary && t.hasSelectedText() {
-		t.copySelectedText(fyne.CurrentApp().Clipboard())
-	}
 
 	if t.onMouseDown == nil {
 		return


### PR DESCRIPTION
Automatically copy selected text on mouse press and paste clipboard contents on right-click. Removes redundant copy on right-click release to streamline text interactions.