### PR TITLE
Add word selection on double-tap

### DIFF
--- a/position.go
+++ b/position.go
@@ -20,3 +20,11 @@ func (t *Terminal) getTermPosition(pos fyne.Position) position {
 	row := int(pos.Y/cell.Height) + 1
 	return position{col, row}
 }
+
+// getPixelPosition converts a terminal position (row and col) to pixel coordinates.
+func (t *Terminal) getPixelPosition(pos position) fyne.Position {
+	cell := t.guessCellSize()
+	x := (pos.Col - 1) * int(cell.Width)  // Convert column to pixel position (1-based to 0-based)
+	y := (pos.Row - 1) * int(cell.Height) // Convert row to pixel position (1-based to 0-based)
+	return fyne.NewPos(float32(x), float32(y))
+}

--- a/position.go
+++ b/position.go
@@ -21,8 +21,8 @@ func (t *Terminal) getTermPosition(pos fyne.Position) position {
 	return position{col, row}
 }
 
-// getPixelPosition converts a terminal position (row and col) to pixel coordinates.
-func (t *Terminal) getPixelPosition(pos position) fyne.Position {
+// getTextPosition converts a terminal position (row and col) to fyne coordinates.
+func (t *Terminal) getTextPosition(pos position) fyne.Position {
 	cell := t.guessCellSize()
 	x := (pos.Col - 1) * int(cell.Width)  // Convert column to pixel position (1-based to 0-based)
 	y := (pos.Row - 1) * int(cell.Height) // Convert row to pixel position (1-based to 0-based)

--- a/select.go
+++ b/select.go
@@ -52,6 +52,8 @@ func (t *Terminal) clearSelectedText() {
 	t.Refresh()
 	t.blockMode = false
 	t.selecting = false
+	t.selStart = nil
+	t.selEnd = nil
 }
 
 // SelectedText gets the text that is currently selected.

--- a/select_test.go
+++ b/select_test.go
@@ -136,27 +136,27 @@ func TestDoubleTapped(t *testing.T) {
 		expectedWord  string
 	}{
 		"Double tap on 'Hello'": {
-			clickPosition: term.getPixelPosition(position{Row: 1, Col: 1}),
+			clickPosition: term.getTextPosition(position{Row: 1, Col: 1}),
 			expectedWord:  "Hello",
 		},
 		"Double tap on 'World'": {
-			clickPosition: term.getPixelPosition(position{Row: 1, Col: 7}),
+			clickPosition: term.getTextPosition(position{Row: 1, Col: 7}),
 			expectedWord:  "World",
 		},
 		"Double tap on '123'": {
-			clickPosition: term.getPixelPosition(position{Row: 2, Col: 9}),
+			clickPosition: term.getTextPosition(position{Row: 2, Col: 9}),
 			expectedWord:  "123",
 		},
 		"Double tap on '!' should not select": {
-			clickPosition: term.getPixelPosition(position{Row: 1, Col: 12}),
+			clickPosition: term.getTextPosition(position{Row: 1, Col: 12}),
 			expectedWord:  "",
 		},
 		"Double tap on '.' should not select": {
-			clickPosition: term.getPixelPosition(position{Row: 2, Col: 12}),
+			clickPosition: term.getTextPosition(position{Row: 2, Col: 12}),
 			expectedWord:  "",
 		},
 		"Double tap on space between words": {
-			clickPosition: term.getPixelPosition(position{Row: 1, Col: 6}),
+			clickPosition: term.getTextPosition(position{Row: 1, Col: 6}),
 			expectedWord:  "",
 		},
 	}


### PR DESCRIPTION
Implement word selection functionality triggered by a double-tap. Words are identified as sequences of alphanumeric characters, while spaces and punctuation are ignored. Update the selection logic to highlight the word under the cursor and clear any existing selection. Adjust tests to validate word selection and ensure accurate behavior when tapping on non-alphanumeric characters.