### PR TITLE
Prevent keypress panic

### DIFF
--- a/input.go
+++ b/input.go
@@ -232,3 +232,13 @@ func (t *Terminal) typeCursorKey(key fyne.KeyName) {
 		_, _ = t.in.Write([]byte{asciiEscape, cursorPrefix, 'C'})
 	}
 }
+
+type discardWriter struct{}
+
+func (d discardWriter) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (d discardWriter) Close() error {
+	return nil
+}

--- a/term.go
+++ b/term.go
@@ -464,6 +464,7 @@ func New() *Terminal {
 	t := &Terminal{
 		mouseCursor:      desktop.DefaultCursor,
 		highlightBitMask: 0x55,
+		in:               discardWriter{},
 	}
 	t.ExtendBaseWidget(t)
 	t.content = widget2.NewTermGrid()


### PR DESCRIPTION
Prevent panic when a keystoke is made before the input steam is ready. This typically happens during ssh connections (slow ssh connections), The input stream is nil before the connection is established and a keypress causes a panic because input is nil