### PR TITLE
Add fyne.Do to t.TextGrid.Refresh. Prevents loop scrolling on term resize.

### DIFF
--- a/internal/widget/termgrid.go
+++ b/internal/widget/termgrid.go
@@ -40,7 +40,7 @@ func NewTermGrid() *TermGrid {
 // We update our blinking status and then call the TextGrid we extended to refresh too.
 func (t *TermGrid) Refresh() {
 	t.refreshBlink(false)
-	t.TextGrid.Refresh()
+	fyne.Do(t.TextGrid.Refresh)
 }
 
 func (t *TermGrid) refreshBlink(blink bool) {
@@ -56,7 +56,7 @@ func (t *TermGrid) refreshBlink(blink bool) {
 			}
 		}
 	}
-	t.TextGrid.Refresh()
+	fyne.Do(t.TextGrid.Refresh)
 
 	switch {
 	case shouldBlink && t.tickerCancel == nil:


### PR DESCRIPTION
This seems to fix issues with resizing causing lag and text to loop and haven't been able to generate an out of bounds issue.