### PR TITLE
Remove duplicate refresh

### DIFF
--- a/internal/widget/termgrid.go
+++ b/internal/widget/termgrid.go
@@ -40,7 +40,6 @@ func NewTermGrid() *TermGrid {
 // We update our blinking status and then call the TextGrid we extended to refresh too.
 func (t *TermGrid) Refresh() {
 	t.refreshBlink(false)
-	t.TextGrid.Refresh()
 }
 
 func (t *TermGrid) refreshBlink(blink bool) {


### PR DESCRIPTION
`refreshBlink` already calls `t.TextGrid.Refresh()`, so this was causing the very expensive `Refresh()` to run twice. 