### PR TITLE
Fix booting fish shell

### DIFF
--- a/dcs.go
+++ b/dcs.go
@@ -1,0 +1,23 @@
+package terminal
+
+import (
+	"encoding/hex"
+	"log"
+)
+
+func (t *Terminal) handleDCS(code string) {
+	if len(code) >= 2 && code[:2] == "+q" {
+		query, _ := hex.DecodeString(code[2:]) // strip the +q
+		if t.debug {
+			log.Println("unhandled DCS query", query)
+		}
+
+		_, _ = t.in.Write([]byte{asciiEscape})
+		_, _ = t.in.Write([]byte("P0+r")) // return not recognised - TODO actually return results
+		_, _ = t.in.Write([]byte{asciiEscape, '\\', 0})
+	} else {
+		if t.debug {
+			log.Println("unknown DCS query", code)
+		}
+	}
+}

--- a/escape.go
+++ b/escape.go
@@ -446,7 +446,9 @@ func escapePrinterMode(t *Terminal, code string) {
 }
 
 func escapeDeviceAttribute(t *Terminal, code string) {
-	if len(code) == 0 {
+	if len(code) == 0 { // query
+		_, _ = t.in.Write([]byte{asciiEscape})
+		_, _ = t.in.Write([]byte("[?2;22c")) // printer; color
 		return
 	}
 
@@ -456,6 +458,8 @@ func escapeDeviceAttribute(t *Terminal, code string) {
 			log.Println("Unhandled secondary device attribute", code[1])
 		case '=':
 			log.Println("Unhandled tertiary device attribute", code[1])
+		default:
+			log.Println("Unknown device attribute", code[0])
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fyne-io/terminal
 go 1.19
 
 require (
-	fyne.io/fyne/v2 v2.6.2-0.20250928194716-af93936fca00
+	fyne.io/fyne/v2 v2.6.2-0.20250930200528-e0524305d606
 	github.com/ActiveState/termtest/conpty v0.5.0
 	github.com/creack/pty v1.1.21
 	github.com/fyshos/fancyfs v0.0.0-20250930151016-696fe12cefc6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 fyne.io/fyne/v2 v2.6.2-0.20250928194716-af93936fca00 h1:JIY5abv6O1ry7b4TwzsWqhTxHZaJFawknDQO8ruzLV0=
 fyne.io/fyne/v2 v2.6.2-0.20250928194716-af93936fca00/go.mod h1:xClVlrhxl7D+LT+BWYmcrW4Nf+dJTvkhnPgji7spAwE=
+fyne.io/fyne/v2 v2.6.2-0.20250930200528-e0524305d606 h1:Pu1mnDftpljviijjkfKqTxKyCYJkmBqO+9assMel2nk=
+fyne.io/fyne/v2 v2.6.2-0.20250930200528-e0524305d606/go.mod h1:xClVlrhxl7D+LT+BWYmcrW4Nf+dJTvkhnPgji7spAwE=
 fyne.io/systray v1.11.1-0.20250603113521-ca66a66d8b58 h1:eA5/u2XRd8OUkoMqEv3IBlFYSruNlXD8bRHDiqm0VNI=
 fyne.io/systray v1.11.1-0.20250603113521-ca66a66d8b58/go.mod h1:RVwqP9nYMo7h5zViCBHri2FgjXF7H2cub7MAq4NSoLs=
 github.com/ActiveState/termtest/conpty v0.5.0 h1:JLUe6YDs4Jw4xNPCU+8VwTpniYOGeKzQg4SM2YHQNA8=

--- a/term.go
+++ b/term.go
@@ -318,6 +318,9 @@ func (t *Terminal) onConfigure() {
 }
 
 func (t *Terminal) open() error {
+	for t.config.Columns <= 2 { // wait until it has a valid area
+		time.Sleep(time.Millisecond * 10)
+	}
 	in, out, pty, err := t.startPTY()
 	if err != nil {
 		return err

--- a/term_unix.go
+++ b/term_unix.go
@@ -44,7 +44,7 @@ func (t *Terminal) startPTY() (io.WriteCloser, io.Reader, io.Closer, error) {
 	go func() {
 		for {
 			time.Sleep(time.Millisecond * 250)
-			if time.Now().Sub(lastKeyTime).Seconds() > 0.5 {
+			if time.Since(lastKeyTime).Seconds() > 0.5 {
 				continue
 			}
 			wd, _ := os.Readlink("/proc/" + strconv.Itoa(c.Process.Pid) + "/cwd")


### PR DESCRIPTION
Fish shell since v4.1.1 requires certain queries to boot cleanly.
This makes it start faster and also removes new error message prints.