### PR TITLE
Debounce resize.

### DIFF
--- a/term.go
+++ b/term.go
@@ -238,30 +238,29 @@ func (t *Terminal) Resize(s fyne.Size) {
 	if t.resizeTimer != nil {
 		t.resizeTimer.Stop()
 	}
-	fyne.Do(func() {
-		t.resizeTimer = time.AfterFunc(resizeDebounce, func() {
-			cellSize := t.guessCellSize()
-			cols := uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
-			rows := uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))
-			if (t.config.Columns == cols) && (t.config.Rows == rows) {
-				return
-			}
+	t.resizeTimer = time.AfterFunc(resizeDebounce, func() {
+		cellSize := t.guessCellSize()
+		cols := uint(math.Floor(float64(s.Width) / float64(cellSize.Width)))
+		rows := uint(math.Floor(float64(s.Height) / float64(cellSize.Height)))
+		if (t.config.Columns == cols) && (t.config.Rows == rows) {
+			return
+		}
 
-			t.BaseWidget.Resize(s)
-			if t.content != nil {
-				t.content.Resize(fyne.NewSize(float32(cols)*cellSize.Width, float32(rows)*cellSize.Height))
-			}
+		t.BaseWidget.Resize(s)
+		if t.content != nil {
+			t.content.Resize(fyne.NewSize(float32(cols)*cellSize.Width, float32(rows)*cellSize.Height))
+		}
 
-			oldRows := int(t.config.Rows)
-			t.config.Columns, t.config.Rows = cols, rows
-			if t.scrollBottom == 0 || t.scrollBottom == oldRows-1 {
-				t.scrollBottom = int(t.config.Rows) - 1
-			}
-			t.onConfigure()
+		oldRows := int(t.config.Rows)
+		t.config.Columns, t.config.Rows = cols, rows
+		if t.scrollBottom == 0 || t.scrollBottom == oldRows-1 {
+			t.scrollBottom = int(t.config.Rows) - 1
+		}
+		t.onConfigure()
 
-			t.updatePTYSize()
-		})
+		t.updatePTYSize()
 	})
+
 }
 
 // SetDebug turns on output about terminal codes and other errors if the parameter is `true`.


### PR DESCRIPTION
This is to cut down on the number of resize operations on the terminal when manually resizing the window.  Slowdown from floating point math and rerender is especially prevalent when when in `systemctl status` or `nano` and resizing the window.

Right now set at 100ms, which feels right to me.

EDIT: Not sure if fyne.Do is needed for function in time.AfterFunc()