### PR TITLE
FIXES #140 and puts a guaranteed refresh every 100ms.

### DIFF
--- a/term.go
+++ b/term.go
@@ -24,7 +24,7 @@ import (
 const (
 	bufLen             = 32768 // 32KB buffer for output, to align with modern L1 cache
 	highlightBitMask   = 0x55
-	maxRefreshInterval = 33 * time.Millisecond
+	maxRefreshInterval = 17 * time.Millisecond
 )
 
 // Config is the state of a terminal, updated upon certain actions or commands.

--- a/term.go
+++ b/term.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	bufLen           = 32768 // 32KB buffer for output, to align with modern L1 cache
-	highlightBitMask = 0x55
+	bufLen             = 32768 // 32KB buffer for output, to align with modern L1 cache
+	highlightBitMask   = 0x55
+	maxRefreshInterval = 100 * time.Millisecond
 )
 
 // Config is the state of a terminal, updated upon certain actions or commands.
@@ -93,6 +94,7 @@ type Terminal struct {
 	disableAutoWrap        bool // disable auto wrap mode (DECAWM off)
 	lastChar               rune // last graphic character output (for CSI b REP)
 	state                  *parseState
+	lastRefresh            time.Time
 	blinking               bool
 	printData              []byte
 	printer                Printer
@@ -415,7 +417,10 @@ func (t *Terminal) run() {
 		}
 
 		leftOver = t.handleOutput(fullBuf[:num])
-		fyne.Do(t.Refresh)
+		if len(leftOver) == 0 || time.Since(t.lastRefresh) > maxRefreshInterval {
+			t.lastRefresh = time.Now()
+			fyne.DoAndWait(t.Refresh)
+		}
 	}
 }
 

--- a/term.go
+++ b/term.go
@@ -24,7 +24,7 @@ import (
 const (
 	bufLen             = 32768 // 32KB buffer for output, to align with modern L1 cache
 	highlightBitMask   = 0x55
-	maxRefreshInterval = 100 * time.Millisecond
+	maxRefreshInterval = 33 * time.Millisecond
 )
 
 // Config is the state of a terminal, updated upon certain actions or commands.


### PR DESCRIPTION
This FIXES #140 and also addresses concerns with #144.

Will force a refresh every at least every 100ms (1/10th of a second) if data is still coming in and the buffer isn't emptied in a timely manner.

Ran the rest suite, and verfied that #140 was addressed as well as that updates still happen with reasonable frequency using `ttyplay -n` and fast curses Nethack game recordings.