### PR TITLE
Handle wide characters (CJK/Hangul) using go-runewidth

### DIFF
--- a/escape.go
+++ b/escape.go
@@ -104,8 +104,8 @@ func (t *Terminal) clearScreen() {
 
 func (t *Terminal) clearScreenFromCursor() {
 	row := t.content.Row(t.cursorRow)
-	from := t.cursorCol
-	if t.cursorCol > len(row.Cells) {
+	from := t.cellStart(t.cursorRow, t.cursorCol)
+	if from > len(row.Cells) {
 		from = len(row.Cells)
 	}
 	if from > 0 {
@@ -121,9 +121,10 @@ func (t *Terminal) clearScreenFromCursor() {
 
 func (t *Terminal) clearScreenToCursor() {
 	row := t.content.Row(t.cursorRow)
-	cells := make([]widget.TextGridCell, t.cursorCol)
-	if t.cursorCol < len(row.Cells) {
-		cells = append(cells, row.Cells[t.cursorCol:]...)
+	end := t.cellEnd(t.cursorRow, t.cursorCol)
+	cells := make([]widget.TextGridCell, end)
+	if end < len(row.Cells) {
+		cells = append(cells, row.Cells[end:]...)
 	}
 
 	t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: cells})
@@ -183,16 +184,24 @@ func escapeColorMode(t *Terminal, msg string) {
 }
 
 func escapeDeleteChars(t *Terminal, msg string) {
-	i, _ := strconv.Atoi(msg)
-	if i == 0 {
-		i = 1
+	count, _ := strconv.Atoi(msg)
+	if count == 0 {
+		count = 1
 	}
-	right := t.cursorCol + i
 
 	row := t.content.Row(t.cursorRow)
-	cells := row.Cells[:t.cursorCol]
-	if right < len(row.Cells) {
-		cells = append(cells, row.Cells[right:]...)
+	start := t.cursorCol
+	for start > 0 && start < len(row.Cells) && row.Cells[start].Rune == 0 {
+		start--
+	}
+	end := start + count
+	for end < len(row.Cells) && row.Cells[end].Rune == 0 {
+		end++
+	}
+
+	cells := row.Cells[:start]
+	if end < len(row.Cells) {
+		cells = append(cells, row.Cells[end:]...)
 	}
 
 	t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: cells})
@@ -207,13 +216,21 @@ func escapeEraseChars(t *Terminal, msg string) {
 	}
 
 	row := t.content.Row(t.cursorRow)
+	start := t.cursorCol
+	for start > 0 && start < len(row.Cells) && row.Cells[start].Rune == 0 {
+		start--
+	}
+	end := start + count
+	for end < len(row.Cells) && row.Cells[end].Rune == 0 {
+		end++
+	}
+
 	cellStyle := &widget.CustomTextGridStyle{FGColor: t.currentFG, BGColor: t.currentBG}
-	// Extend row if cursor is beyond current length
-	for len(row.Cells) < t.cursorCol+count {
+	for len(row.Cells) < end {
 		row.Cells = append(row.Cells, widget.TextGridCell{Rune: ' ', Style: cellStyle})
 	}
-	for i := 0; i < count; i++ {
-		row.Cells[t.cursorCol+i] = widget.TextGridCell{Rune: ' ', Style: cellStyle}
+	for i := start; i < end; i++ {
+		row.Cells[i] = widget.TextGridCell{Rune: ' ', Style: cellStyle}
 	}
 	t.content.SetRow(t.cursorRow, row)
 }
@@ -274,17 +291,20 @@ func escapeEraseInLine(t *Terminal, msg string) {
 	switch mode {
 	case 0:
 		row := t.content.Row(t.cursorRow)
-		if t.cursorCol >= len(row.Cells) {
+		start := t.cellStart(t.cursorRow, t.cursorCol)
+		if start >= len(row.Cells) {
 			return
 		}
-		t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: row.Cells[:t.cursorCol]})
+		t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: row.Cells[:start]})
 	case 1:
 		row := t.content.Row(t.cursorRow)
-		if t.cursorCol >= len(row.Cells) {
+		end := t.cellEnd(t.cursorRow, t.cursorCol)
+		if end >= len(row.Cells) {
+			t.content.SetRow(t.cursorRow, widget.TextGridRow{})
 			return
 		}
-		cells := make([]widget.TextGridCell, t.cursorCol)
-		t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: append(cells, row.Cells[t.cursorCol:]...)})
+		cells := make([]widget.TextGridCell, end)
+		t.content.SetRow(t.cursorRow, widget.TextGridRow{Cells: append(cells, row.Cells[end:]...)})
 	case 2:
 		t.content.SetRow(t.cursorRow, widget.TextGridRow{})
 	}
@@ -308,6 +328,8 @@ func escapeInsertChars(t *Terminal, msg string) {
 		chars = 1
 	}
 
+	insertCol := t.cellStart(t.cursorRow, t.cursorCol)
+
 	newCells := make([]widget.TextGridCell, chars)
 	cellStyle := &widget.CustomTextGridStyle{FGColor: t.currentFG, BGColor: t.currentBG, TextStyle: fyne.TextStyle{Monospace: true}}
 	for i := range newCells {
@@ -318,7 +340,7 @@ func escapeInsertChars(t *Terminal, msg string) {
 	}
 
 	row := &t.content.Rows[t.cursorRow]
-	row.Cells = append(row.Cells[:t.cursorCol], append(newCells, row.Cells[t.cursorCol:]...)...)
+	row.Cells = append(row.Cells[:insertCol], append(newCells, row.Cells[insertCol:]...)...)
 }
 
 func escapeInsertLines(t *Terminal, msg string) {

--- a/output.go
+++ b/output.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/widget"
 	widget2 "github.com/fyne-io/terminal/internal/widget"
+	"github.com/mattn/go-runewidth"
 )
 
 const (
@@ -284,12 +285,22 @@ func (t *Terminal) parseDCS(r rune) {
 }
 
 func (t *Terminal) handleOutputChar(r rune) {
-	if t.cursorCol == int(t.config.Columns) {
+	w := runewidth.RuneWidth(r)
+	if w == 0 {
+		// Zero-width runes get their own cell as a best-effort.
+		w = 1
+	}
+
+	// Wrap if the character does not fit on the current line.
+	if t.cursorCol+w > int(t.config.Columns) {
 		if !t.disableAutoWrap {
 			t.cursorCol = 0
 			handleOutputLineFeed(t)
 		} else {
-			// In non-wrap mode, overwrite the last character
+			// Drop wide chars that do not fit when auto-wrap is disabled.
+			if w > 1 {
+				return
+			}
 			t.cursorCol = int(t.config.Columns) - 1
 		}
 	}
@@ -297,7 +308,6 @@ func (t *Terminal) handleOutputChar(r rune) {
 	var cellStyle widget.TextGridStyle
 	textStyle := fyne.TextStyle{
 		Monospace: true,
-
 		Bold:          t.bold,
 		Italic:        t.italic,
 		Underline:     t.underline,
@@ -322,8 +332,14 @@ func (t *Terminal) handleOutputChar(r rune) {
 			t.content.Rows[row].Cells[i].Rune = ' '
 		}
 	}
+
+	// Fill continuation cells for wide chars.
+	for i := 1; i < w; i++ {
+		t.content.SetCell(row, col+i, widget.TextGridCell{Rune: 0, Style: cellStyle})
+	}
+
 	t.lastChar = r
-	t.cursorCol++
+	t.cursorCol += w
 }
 
 func (t *Terminal) ringBell() {

--- a/term.go
+++ b/term.go
@@ -12,6 +12,7 @@ import (
 	"unicode"
 
 	widget2 "github.com/fyne-io/terminal/internal/widget"
+	"github.com/mattn/go-runewidth"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -599,4 +600,37 @@ type ReadWriterConfiguratorFunc func(r io.Reader, w io.WriteCloser) (io.Reader, 
 // It calls the ReadWriterConfiguratorFunc itself.
 func (m ReadWriterConfiguratorFunc) SetupReadWriter(r io.Reader, w io.WriteCloser) (io.Reader, io.WriteCloser) {
 	return m(r, w)
+}
+
+func (t *Terminal) cellStart(row, col int) int {
+	if col <= 0 {
+		return 0
+	}
+	r := t.content.Row(row)
+	if col >= len(r.Cells) {
+		return col
+	}
+	if r.Cells[col].Rune != 0 {
+		return col
+	}
+	for col > 0 && r.Cells[col].Rune == 0 {
+		col--
+	}
+	return col
+}
+
+func (t *Terminal) cellEnd(row, col int) int {
+	if col < 0 {
+		return 0
+	}
+	start := t.cellStart(row, col)
+	r := t.content.Row(row)
+	if start >= len(r.Cells) {
+		return start
+	}
+	w := runewidth.RuneWidth(r.Cells[start].Rune)
+	if w <= 0 {
+		return start + 1
+	}
+	return start + w
 }


### PR DESCRIPTION
- Calculate character width with runewidth.RuneWidth in handleOutputChar
- Fill continuation cells (Rune: 0) for multi-column wide characters
- Remove cellStart snap from handleOutputBackspace: BS must move exactly 1 column
- Update escapeDeleteChars and escapeEraseChars to avoid splitting wide chars
- Add cellStart/cellEnd helpers for wide char boundary alignment